### PR TITLE
Reworked wikipedia_reference_scraper.py to take command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ to copy and paste the references. This was a lot of work considering the fact th
 working with just one page. I decided to make use of Wikipedia API wrappers but all the ones I checked didn't do what I needed. So
 I decided to write a simple script that scraped Wikipedia page.
 
-# Usage in a Python Interactive Shell
+# Usage
+
+## Python Interactive Shell
 
 ```
->>> from wikipedia_reference_scraper import write_to_document
+>>> from wikipedia_reference_scraper import WikipediaReferenceScraper as wrs
 
->>> write_to_document('https://en.wikipedia.org/wiki/Blood_pressure#References', 'filename.docx')
+>>> wrs().write_to_document('https://en.wikipedia.org/wiki/Blood_pressure#References', 'filename.docx')
 ```
+
+## Through the Command Line (with python-fire)
+
+```
+$ python wikipedia_reference_scraper.py write_to_document https://en.wikipedia.org/wiki/Blood_pressure#References filename.docx
+```
+
 It pulls the references from a Wikipedia page and saves the references in a file.
 
 # Tools I Used
@@ -23,3 +32,5 @@ It pulls the references from a Wikipedia page and saves the references in a file
 Requests
 
 BeautifulSoup
+
+python-fire

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 beautifulsoup4==4.6.0
 certifi==2018.1.18
 chardet==3.0.4
+fire==0.1.3
 idna==2.6
-pkg-resources==0.0.0
 requests==2.18.4
+six==1.11.0
 urllib3==1.22
 wi==0.0.2

--- a/wikipedia_reference_scraper.py
+++ b/wikipedia_reference_scraper.py
@@ -1,59 +1,54 @@
 import requests
 from bs4 import BeautifulSoup
+import fire
 
 
-def get_url_page(url):
-    '''
-    This function creates a response object for the url that is
-    to be scrapped.
+class WikipediaReferenceScraper(object):
 
-    :param url: This is the url of the page that is to be scrapped
-    :return: IT returns the a response object of the url
-    '''
-    page = requests.get(url)
-    if page.status_code == 200:
-        return page.text
-    else:
-        print('Check the url entered')
+    def get_url_page(self, url):
+        '''
+        This function creates a response object for the url that is
+        to be scrapped.
 
-
-def get_references(url):
-    '''
-    This function calls the get_url_page() function.
-    The response from the get_url_page() function is parsed as html.
-
-    :param url: This is the url of the page that is to be scrapped
-    :return: The return object is an html object
-    '''
-    page_text = get_url_page(url)
-    soup = BeautifulSoup(page_text, 'html.parser')
-    citations = soup.find_all('cite')
-    return citations
+        :param url: This is the url of the page that is to be scrapped
+        :return: IT returns the a response object of the url
+        '''
+        page = requests.get(url)
+        if page.status_code == 200:
+            return page.text
+        else:
+            print('Check the url entered')
 
 
-def write_to_document(url, document_name):
-    '''
-    This is the main fucntion that calls the above fucntions and then does the actual write to
-    document.
+    def get_references(self, url):
+        '''
+        This function calls the get_url_page() function.
+        The response from the get_url_page() function is parsed as html.
 
-    :param url: This is the url of the page that is to be scrapped
-    :param document_name: The name of the document that our scrapped data will be written to
-    :return: There is no return object
-    '''
-    with open(document_name, 'w') as file:
-        for citation in get_references(url):
-            file.write('\n\n')
-            for string in citation.strings:
-                file.write(string)
+        :param url: This is the url of the page that is to be scrapped
+        :return: The return object is an html object
+        '''
+        page_text = self.get_url_page(url)
+        soup = BeautifulSoup(page_text, 'html.parser')
+        citations = soup.find_all('cite')
+        return citations
 
 
+    def write_to_document(self, url, document_name):
+        '''
+        This is the main fucntion that calls the above fucntions and then does the actual write to
+        document.
+
+        :param url: This is the url of the page that is to be scrapped
+        :param document_name: The name of the document that our scrapped data will be written to
+        :return: There is no return object
+        '''
+        with open(document_name, 'w') as file:
+            for citation in self.get_references(url):
+                file.write('\n\n')
+                for string in citation.strings:
+                    file.write(string)
 
 
-
-
-
-
-
-
-
-
+if __name__ == '__main__':
+  fire.Fire(WikipediaReferenceScraper)


### PR DESCRIPTION
Updated README.md to reflect this new option.

Command Line Arguments are accepted with the python-fire library and six dependency, which is now reflected in requirements.txt

Removed pkg-resources==0.0.0 from requirements.txt, I think it is unnecessary.